### PR TITLE
Callback function promise should be optional

### DIFF
--- a/zInfiniteScroll.js
+++ b/zInfiniteScroll.js
@@ -53,11 +53,14 @@
                     // if we have reached the threshold and we scroll up
                     if (scrolled < lengthThreshold && (scrolled - lastScrolled) < 0 && (element.scrollHeight >= element.clientHeight)) {
                         var originalHeight = element.scrollHeight;
-                        $scope.$apply(handler).then(function() {
-                            $timeout(function() {
-                                element.scrollTop = element.scrollHeight - originalHeight;
+                        var handlerCallback = $scope.$apply(handler);
+                        if (handlerCallback && typeof handlerCallback.then === 'function') {
+                            handlerCallback.then(function() {
+                                $timeout(function() {
+                                    element.scrollTop = element.scrollHeight - originalHeight;
+                                });
                             });
-                        });
+                        }
                     }
                     lastScrolled = scrolled;
                 }


### PR DESCRIPTION
Once the user has lazy loaded all of the available content from the database, the front-end should no longer continue sending HTTP requests for further pagination. Without an HTTP request, no promise is returned, unless we return a fake `$q.defer().promise` object like this:

```
var deferred = $q.defer();
deferred.resolve();
return deferred.promise;
```

 That is superfluous though, compared with simply not having this promise as a requirement. 
